### PR TITLE
when a value is passed as a symbol, do not quote it

### DIFF
--- a/libraries/_common.rb
+++ b/libraries/_common.rb
@@ -136,7 +136,7 @@ module SyslogNg
     end
 
     def format_parameter_pair(parameter:, value:, named: true)
-      raise ArgumentError, "format_parameter_pair: Type error, got #{parameter.class} and #{value.class}. Expected String and String/Integer." unless parameter.is_a?(String) && (value.is_a?(String) || value.is_a?(Integer))
+      raise ArgumentError, "format_parameter_pair: Type error, got #{parameter.class} and #{value.class}. Expected String and String/Integer/Symbol." unless parameter.is_a?(String) && (value.is_a?(String) || value.is_a?(Integer) || value.is_a?(Symbol))
 
       parameter_value = value.is_a?(String) && !value.match?('"') ? format_string_value(value) : value.to_s # TODO: Don't like this matching for already quoted strings
       parameter_string = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bmhughes@bmhughes.co.uk'
 license 'Apache-2.0'
 description 'Installs/Configures syslog_ng'
 long_description 'Installs/Configures syslog_ng'
-version '0.3.1'
+version '0.3.2'
 chef_version '>= 12.14' if respond_to?(:chef_version)
 
 # The `issues_url` points to the location where issues for this cookbook are


### PR DESCRIPTION
I was getting the error:

Error parsing afsocket, syntax error, unexpected LL_STRING, expecting KW_PERSIST_ONLY or KW_YES or KW_NO or LL_NUMBER in /etc/syslog-ng/source.d/remote_apache2_listener.conf:
8----->     syslog(ip(0.0.0.0) port(3331) max-connections(100) log_iw_size(10000) use_dns("persist_only") log_msg_size(32768));

I needed a way on not quoting a string value (persist_only) and I could not see how without the following patch.